### PR TITLE
fix: group on cluster label in addition to pool_id

### DIFF
--- a/alerts/pool-quota.libsonnet
+++ b/alerts/pool-quota.libsonnet
@@ -7,7 +7,7 @@
           {
             alert: 'CephPoolQuotaBytesNearExhaustion',
             expr: |||
-              (ceph_pool_stored_raw * on (pool_id) group_left(name)ceph_pool_metadata) / ((ceph_pool_quota_bytes * on (pool_id) group_left(name)ceph_pool_metadata) > 0) > 0.70
+              (ceph_pool_stored_raw * on (pool_id, cluster) group_left(name)ceph_pool_metadata) / ((ceph_pool_quota_bytes * on (pool_id, cluster) group_left(name)ceph_pool_metadata) > 0) > 0.70
             |||,
             'for': $._config.poolQuotaUtilizationAlertTime,
             labels: {
@@ -23,7 +23,7 @@
           {
             alert: 'CephPoolQuotaBytesCriticallyExhausted',
             expr: |||
-              (ceph_pool_stored_raw * on (pool_id) group_left(name)ceph_pool_metadata) / ((ceph_pool_quota_bytes * on (pool_id) group_left(name)ceph_pool_metadata) > 0) > 0.90
+              (ceph_pool_stored_raw * on (pool_id, cluster) group_left(name)ceph_pool_metadata) / ((ceph_pool_quota_bytes * on (pool_id, cluster) group_left(name)ceph_pool_metadata) > 0) > 0.90
             |||,
             'for': $._config.poolQuotaUtilizationAlertTime,
             labels: {


### PR DESCRIPTION
This resolves an issue where in our environment, we have multiple Ceph clusters. With multiple Ceph clusters, these rules are failing to evaluate:
```
found duplicate series for the match group {pool_id=\"8\"} on the right hand-side of the operation: .... REDACTED QUERIES/LABELS .... many-to-many matching not allowed: matching labels must be unique on one side
```